### PR TITLE
fix(stylua): adjust the default target maximum line length to 80

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,4 +1,4 @@
-column_width = 120
+column_width = 80
 line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2


### PR DESCRIPTION
While there is no hard or fast style guide recommendations about this, I find reading things to be much more difficult after reaching column 80. Some individuals use 120 instead, but I think that's blasphemous and immoral.